### PR TITLE
Fix: "setinfo toggle desubtick exploit" crash when disconnecting

### DIFF
--- a/CSAFAP/addons/multi/+duck.cfg
+++ b/CSAFAP/addons/multi/+duck.cfg
@@ -1,2 +1,1 @@
-setinfo duck 0
 toggle duck "1 0 0"

--- a/CSAFAP/addons/multi/+jump.cfg
+++ b/CSAFAP/addons/multi/+jump.cfg
@@ -1,2 +1,1 @@
-setinfo jump 0
 toggle jump "1 0 0"

--- a/CSAFAP/addons/multi/+walk.cfg
+++ b/CSAFAP/addons/multi/+walk.cfg
@@ -1,2 +1,1 @@
-setinfo sprint 0
 toggle sprint "1 0 0"

--- a/CSAFAP/addons/multi/-duck.cfg
+++ b/CSAFAP/addons/multi/-duck.cfg
@@ -1,2 +1,1 @@
-setinfo duck 0
 toggle duck "-999 0 0"

--- a/CSAFAP/addons/multi/-jump.cfg
+++ b/CSAFAP/addons/multi/-jump.cfg
@@ -1,2 +1,1 @@
-setinfo jump 0
 toggle jump "-999 0 0"

--- a/CSAFAP/addons/multi/-walk.cfg
+++ b/CSAFAP/addons/multi/-walk.cfg
@@ -1,2 +1,1 @@
-setinfo sprint 0
 toggle sprint "-999 0 0"

--- a/CSAFAP/logic.cfg
+++ b/CSAFAP/logic.cfg
@@ -79,6 +79,10 @@ alias reset_JTmouse_y "exec CSAFAP/addons/multi/-forward; bind 3 slot3; sens_res
 
 // === de-subtick jump (credit to Leiti https://github.com/xLeiti) ===
 // alias to other keys are loaded with <exec csafap/movement/desubtick>
+setinfo jump 0
+setinfo duck 0
+setinfo sprint 0
+
 alias +jump_ "exec "CSAFAP/addons/multi/+jump"
 alias -jump_ "exec "CSAFAP/addons/multi/-jump"
 


### PR DESCRIPTION
using setinfo while connected to a server will cause game crashes when disconnecting from it.
this is the main reason people think a workshop map crashed their game when trying to exit it